### PR TITLE
Add Java toolchain configuration back in

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,12 @@ plugins {
   id 'performance'
 }
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(21)
+  }
+}
+
 performance {
   simulationClass = 'simulations.CacheWarm_Simulation'
   transactionNamesToGraph = ['CCDCacheWarm_000_LoadJurisdictions']


### PR DESCRIPTION
It looks like Jenkins code only looks in the parent build.gradle to identify the version of Java to use, not in the inherited gradle convention plugin code.

